### PR TITLE
rs - Add HelpRequestController with GET and POST

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,0 +1,67 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "HelpRequests")
+@RequestMapping("/api/helprequests")
+@RestController
+@Slf4j
+public class HelpRequestController extends ApiController {
+
+  @Autowired HelpRequestRepository helpRequestRepository;
+
+  @Operation(summary = "List all help requests")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<HelpRequest> allHelpRequests() {
+    Iterable<HelpRequest> helpRequests = helpRequestRepository.findAll();
+    return helpRequests;
+  }
+
+  @Operation(summary = "Create a new help request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public HelpRequest postHelpRequest(
+      @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+      @Parameter(name = "teamId") @RequestParam String teamId,
+      @Parameter(name = "tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+      @Parameter(
+              name = "requestTime",
+              description = "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS)")
+          @RequestParam("requestTime")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime requestTime,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(name = "solved") @RequestParam boolean solved)
+      throws JsonProcessingException {
+
+    log.info("requestTime={}", requestTime);
+
+    HelpRequest helpRequest = new HelpRequest();
+    helpRequest.setRequesterEmail(requesterEmail);
+    helpRequest.setTeamId(teamId);
+    helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+    helpRequest.setRequestTime(requestTime);
+    helpRequest.setExplanation(explanation);
+    helpRequest.setSolved(solved);
+
+    HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+    return savedHelpRequest;
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -1,0 +1,140 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = HelpRequestController.class)
+@Import(TestConfig.class)
+public class HelpRequestControllerTests extends ControllerTestCase {
+
+  @MockitoBean HelpRequestRepository helpRequestRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/helprequests/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/helprequests/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/helprequests/all")).andExpect(status().is(200));
+  }
+
+  // Authorization tests for /api/helprequests/post
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/helprequests/post")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/helprequests/post")).andExpect(status().is(403));
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_helprequests() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T17:35:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-04-20T18:31:00");
+
+    HelpRequest helpRequest1 =
+        HelpRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .teamId("s22-5pm-3")
+            .tableOrBreakoutRoom("7")
+            .requestTime(ldt1)
+            .explanation("Need help with Swagger-ui")
+            .solved(false)
+            .build();
+
+    HelpRequest helpRequest2 =
+        HelpRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .teamId("s22-6pm-3")
+            .tableOrBreakoutRoom("11")
+            .requestTime(ldt2)
+            .explanation("Dokku problems")
+            .solved(false)
+            .build();
+
+    ArrayList<HelpRequest> expectedHelpRequests = new ArrayList<>();
+    expectedHelpRequests.addAll(Arrays.asList(helpRequest1, helpRequest2));
+
+    when(helpRequestRepository.findAll()).thenReturn(expectedHelpRequests);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/helprequests/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(helpRequestRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedHelpRequests);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_helprequest() throws Exception {
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T17:35:00");
+
+    HelpRequest helpRequest1 =
+        HelpRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .teamId("s22-5pm-3")
+            .tableOrBreakoutRoom("7")
+            .requestTime(ldt1)
+            .explanation("Need help with Swagger-ui")
+            .solved(false)
+            .build();
+
+    when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/helprequests/post?requesterEmail=cgaucho@ucsb.edu&teamId=s22-5pm-3&tableOrBreakoutRoom=7&requestTime=2022-04-20T17:35:00&explanation=Need help with Swagger-ui&solved=false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(helpRequestRepository, times(1)).save(helpRequest1);
+    String expectedJson = mapper.writeValueAsString(helpRequest1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -117,7 +117,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
             .tableOrBreakoutRoom("7")
             .requestTime(ldt1)
             .explanation("Need help with Swagger-ui")
-            .solved(false)
+            .solved(true)
             .build();
 
     when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
@@ -126,7 +126,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
     MvcResult response =
         mockMvc
             .perform(
-                post("/api/helprequests/post?requesterEmail=cgaucho@ucsb.edu&teamId=s22-5pm-3&tableOrBreakoutRoom=7&requestTime=2022-04-20T17:35:00&explanation=Need help with Swagger-ui&solved=false")
+                post("/api/helprequests/post?requesterEmail=cgaucho@ucsb.edu&teamId=s22-5pm-3&tableOrBreakoutRoom=7&requestTime=2022-04-20T17:35:00&explanation=Need help with Swagger-ui&solved=true")
                     .with(csrf()))
             .andExpect(status().isOk())
             .andReturn();


### PR DESCRIPTION
## Summary
- Added `HelpRequestController` with two endpoints:
  - `GET /api/helprequests/all` - lists all help requests (requires USER role)
  - `POST /api/helprequests/post` - creates a new help request (requires ADMIN role)
- Added `HelpRequestControllerTests` with 6 tests covering:
  - Authorization (logged out users blocked, regular users can't POST)
  - GET all returns correct data
  - POST creates and returns new record

Closes #33