### PR TITLE
Add PUT endpoint for RecommendationRequest

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -75,5 +78,28 @@ public class RecommendationRequestController extends ApiController {
     recommendationRequest.setDone(done);
 
     return recommendationRequestRepository.save(recommendationRequest);
+  }
+
+  @Operation(summary = "Update a single recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public RecommendationRequest updateRecommendationRequest(
+      @Parameter(name = "id") @RequestParam Long id,
+      @RequestBody @Valid RecommendationRequest incoming) {
+
+    RecommendationRequest recommendationRequest =
+        recommendationRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+    recommendationRequest.setRequesterEmail(incoming.getRequesterEmail());
+    recommendationRequest.setProfessorEmail(incoming.getProfessorEmail());
+    recommendationRequest.setExplanation(incoming.getExplanation());
+    recommendationRequest.setDateRequested(incoming.getDateRequested());
+    recommendationRequest.setDateNeeded(incoming.getDateNeeded());
+    recommendationRequest.setDone(incoming.getDone());
+
+    recommendationRequestRepository.save(recommendationRequest);
+    return recommendationRequest;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.example.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,6 +31,15 @@ public class RecommendationRequestController extends ApiController {
   @GetMapping("/all")
   public Iterable<RecommendationRequest> allRecommendationRequests() {
     return recommendationRequestRepository.findAll();
+  }
+
+  @Operation(summary = "Get a single recommendation request")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public RecommendationRequest getById(@Parameter(name = "id") @RequestParam Long id) {
+    return recommendationRequestRepository
+        .findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
   }
 
   @Operation(summary = "Create a new recommendation request")

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -1,0 +1,69 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "RecommendationRequests")
+@RequestMapping("/api/recommendationrequests")
+@RestController
+@Slf4j
+public class RecommendationRequestController extends ApiController {
+
+  @Autowired RecommendationRequestRepository recommendationRequestRepository;
+
+  @Operation(summary = "List all recommendation requests")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<RecommendationRequest> allRecommendationRequests() {
+    return recommendationRequestRepository.findAll();
+  }
+
+  @Operation(summary = "Create a new recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public RecommendationRequest postRecommendationRequest(
+      @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+      @Parameter(name = "professorEmail") @RequestParam String professorEmail,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(
+              name = "dateRequested",
+              description = "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS)")
+          @RequestParam("dateRequested")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateRequested,
+      @Parameter(
+              name = "dateNeeded",
+              description = "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS)")
+          @RequestParam("dateNeeded")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateNeeded,
+      @Parameter(name = "done") @RequestParam boolean done)
+      throws JsonProcessingException {
+
+    log.info("dateRequested={}, dateNeeded={}", dateRequested, dateNeeded);
+
+    RecommendationRequest recommendationRequest = new RecommendationRequest();
+    recommendationRequest.setRequesterEmail(requesterEmail);
+    recommendationRequest.setProfessorEmail(professorEmail);
+    recommendationRequest.setExplanation(explanation);
+    recommendationRequest.setDateRequested(dateRequested);
+    recommendationRequest.setDateNeeded(dateNeeded);
+    recommendationRequest.setDone(done);
+
+    return recommendationRequestRepository.save(recommendationRequest);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "recommendationrequests")
+public class RecommendationRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String professorEmail;
+  private String explanation;
+  private LocalDateTime dateRequested;
+  private LocalDateTime dateNeeded;
+  private boolean done;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RepositoryRestResource(exported = false)
+public interface RecommendationRequestRepository
+    extends CrudRepository<RecommendationRequest, Long> {}

--- a/src/main/resources/db/migration/changes/RecommendationRequest.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest.json
@@ -1,0 +1,80 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "RecommendationRequest-1",
+        "author": "nathanqiuUCSB",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "RECOMMENDATIONREQUESTS"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "RECOMMENDATIONREQUESTS_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "REQUESTER_EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "PROFESSOR_EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXPLANATION",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DATE_REQUESTED",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DATE_NEEDED",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DONE",
+                    "type": "BOOLEAN"
+                  }
+                }
+              ],
+              "tableName": "RECOMMENDATIONREQUESTS"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -132,7 +132,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
             .explanation("BS/MS program")
             .dateRequested(dr)
             .dateNeeded(dn)
-            .done(false)
+            .done(true)
             .build();
 
     when(recommendationRequestRepository.save(eq(rr))).thenReturn(rr);
@@ -146,7 +146,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
                     .param("explanation", "BS/MS program")
                     .param("dateRequested", "2022-04-20T00:00:00")
                     .param("dateNeeded", "2022-05-01T00:00:00")
-                    .param("done", "false")
+                    .param("done", "true")
                     .with(csrf()))
             .andExpect(status().isOk())
             .andReturn();

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -1,0 +1,158 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = RecommendationRequestController.class)
+@Import(TestConfig.class)
+public class RecommendationRequestControllerTests extends ControllerTestCase {
+
+  @MockitoBean RecommendationRequestRepository recommendationRequestRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/recommendationrequests/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/recommendationrequests/all")).andExpect(status().is(200));
+  }
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/recommendationrequests/post")
+                .param("requesterEmail", "cgaucho@ucsb.edu")
+                .param("professorEmail", "phtcon@ucsb.edu")
+                .param("explanation", "BS/MS program")
+                .param("dateRequested", "2022-04-20T00:00:00")
+                .param("dateNeeded", "2022-05-01T00:00:00")
+                .param("done", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/recommendationrequests/post")
+                .param("requesterEmail", "cgaucho@ucsb.edu")
+                .param("professorEmail", "phtcon@ucsb.edu")
+                .param("explanation", "BS/MS program")
+                .param("dateRequested", "2022-04-20T00:00:00")
+                .param("dateNeeded", "2022-05-01T00:00:00")
+                .param("done", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_recommendationrequests() throws Exception {
+    LocalDateTime dr1 = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime dn1 = LocalDateTime.parse("2022-05-01T00:00:00");
+    LocalDateTime dr2 = LocalDateTime.parse("2022-05-20T00:00:00");
+    LocalDateTime dn2 = LocalDateTime.parse("2022-11-15T00:00:00");
+
+    RecommendationRequest rr1 =
+        RecommendationRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("BS/MS program")
+            .dateRequested(dr1)
+            .dateNeeded(dn1)
+            .done(false)
+            .build();
+
+    RecommendationRequest rr2 =
+        RecommendationRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .professorEmail("richert@ucsb.edu")
+            .explanation("PhD CS Stanford")
+            .dateRequested(dr2)
+            .dateNeeded(dn2)
+            .done(false)
+            .build();
+
+    ArrayList<RecommendationRequest> expected = new ArrayList<>();
+    expected.addAll(Arrays.asList(rr1, rr2));
+
+    when(recommendationRequestRepository.findAll()).thenReturn(expected);
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequests/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expected);
+    assertEquals(expectedJson, response.getResponse().getContentAsString());
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_recommendationrequest() throws Exception {
+    LocalDateTime dr = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime dn = LocalDateTime.parse("2022-05-01T00:00:00");
+
+    RecommendationRequest rr =
+        RecommendationRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("BS/MS program")
+            .dateRequested(dr)
+            .dateNeeded(dn)
+            .done(false)
+            .build();
+
+    when(recommendationRequestRepository.save(eq(rr))).thenReturn(rr);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/recommendationrequests/post")
+                    .param("requesterEmail", "cgaucho@ucsb.edu")
+                    .param("professorEmail", "phtcon@ucsb.edu")
+                    .param("explanation", "BS/MS program")
+                    .param("dateRequested", "2022-04-20T00:00:00")
+                    .param("dateNeeded", "2022-05-01T00:00:00")
+                    .param("done", "false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).save(rr);
+    String expectedJson = mapper.writeValueAsString(rr);
+    assertEquals(expectedJson, response.getResponse().getContentAsString());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -18,6 +18,8 @@ import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -42,6 +44,13 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
   @Test
   public void logged_in_users_can_get_all() throws Exception {
     mockMvc.perform(get("/api/recommendationrequests/all")).andExpect(status().is(200));
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/recommendationrequests").param("id", "7"))
+        .andExpect(status().is(403));
   }
 
   @Test
@@ -117,6 +126,52 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
     verify(recommendationRequestRepository, times(1)).findAll();
     String expectedJson = mapper.writeValueAsString(expected);
     assertEquals(expectedJson, response.getResponse().getContentAsString());
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    LocalDateTime dr = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime dn = LocalDateTime.parse("2022-05-01T00:00:00");
+
+    RecommendationRequest rr =
+        RecommendationRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("BS/MS program")
+            .dateRequested(dr)
+            .dateNeeded(dn)
+            .done(false)
+            .build();
+
+    when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.of(rr));
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequests").param("id", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(rr);
+    assertEquals(expectedJson, response.getResponse().getContentAsString());
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+    when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequests").param("id", "7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
   }
 
   @WithMockUser(roles = {"ADMIN", "USER"})

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edu.ucsb.cs156.example.ControllerTestCase;
@@ -23,6 +24,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -209,5 +211,89 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
     verify(recommendationRequestRepository, times(1)).save(rr);
     String expectedJson = mapper.writeValueAsString(rr);
     assertEquals(expectedJson, response.getResponse().getContentAsString());
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_recommendationrequest() throws Exception {
+    LocalDateTime drOrig = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime dnOrig = LocalDateTime.parse("2022-05-01T00:00:00");
+    LocalDateTime drEdited = LocalDateTime.parse("2022-04-25T00:00:00");
+    LocalDateTime dnEdited = LocalDateTime.parse("2022-05-10T00:00:00");
+
+    RecommendationRequest rrOrig =
+        RecommendationRequest.builder()
+            .requesterEmail("cgaucho@ucsb.edu")
+            .professorEmail("phtcon@ucsb.edu")
+            .explanation("BS/MS program")
+            .dateRequested(drOrig)
+            .dateNeeded(dnOrig)
+            .done(false)
+            .build();
+
+    RecommendationRequest rrEdited =
+        RecommendationRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .professorEmail("richert@ucsb.edu")
+            .explanation("PhD CS Stanford")
+            .dateRequested(drEdited)
+            .dateNeeded(dnEdited)
+            .done(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(rrEdited);
+    when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(rrOrig));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/recommendationrequests")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(67L);
+    verify(recommendationRequestRepository, times(1)).save(rrEdited);
+    assertEquals(requestBody, response.getResponse().getContentAsString());
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_recommendationrequest_that_does_not_exist() throws Exception {
+    LocalDateTime drEdited = LocalDateTime.parse("2022-04-25T00:00:00");
+    LocalDateTime dnEdited = LocalDateTime.parse("2022-05-10T00:00:00");
+
+    RecommendationRequest rrEdited =
+        RecommendationRequest.builder()
+            .requesterEmail("ldelplaya@ucsb.edu")
+            .professorEmail("richert@ucsb.edu")
+            .explanation("PhD CS Stanford")
+            .dateRequested(drEdited)
+            .dateNeeded(dnEdited)
+            .done(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(rrEdited);
+    when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/recommendationrequests")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("RecommendationRequest with id 67 not found", json.get("message"));
   }
 }


### PR DESCRIPTION
## Summary
- Add `PUT /api/recommendationrequests?id={id}` to `RecommendationRequestController`
- Allow admin users to update an existing `RecommendationRequest`
- Return `404` with the appropriate `EntityNotFoundException` message when the id does not exist
- Add controller tests for:
  - successful update of an existing recommendation request
  - 404 response when attempting to update a missing recommendation request

## Testing
- `mvn -Dtest=RecommendationRequestControllerTests test`
- Verified PUT endpoint behavior in controller tests:
  - existing id updates successfully
  - missing id returns `RecommendationRequest with id <id> not found`

Closes #23
